### PR TITLE
Fix php 8.1 errors on unit test serializable.

### DIFF
--- a/test/Horde/Yaml/Helpers.php
+++ b/test/Horde/Yaml/Helpers.php
@@ -36,6 +36,16 @@ class Horde_Yaml_Test_Serializable implements Serializable
         $this->string = $serialized;
     }
 
+    public function __serialize(): array
+    {
+        return [$this->string];
+    }
+
+    public function __unserialize(array $serialized): void
+    {
+        $this->string = array_pop($serialized);
+    }
+
     public function test()
     {
         return $this->string;


### PR DESCRIPTION
Fix PHP 8.1 complaints about serializable. There is an unrelated issue with horde/exception that might cause log spam but will be addressed separately.